### PR TITLE
Add skills, locations, quests, and shops to ECS diagram

### DIFF
--- a/server/ecs-diagram.drawio
+++ b/server/ecs-diagram.drawio
@@ -1,6 +1,6 @@
-<mxfile host="Electron" modified="2023-04-24T15:52:35.246Z" agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/21.2.1 Chrome/106.0.5249.199 Electron/21.4.3 Safari/537.36" etag="XNlyCssoqQLHLsA2DJLI" version="21.2.1" type="device">
+<mxfile host="Electron" modified="2023-04-24T17:34:37.055Z" agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/21.2.1 Chrome/106.0.5249.199 Electron/21.4.3 Safari/537.36" etag="VEhAwenO1JFKADHJYiMU" version="21.2.1" type="device">
   <diagram id="C5RBs43oDa-KdzZeNtuy" name="Page-1">
-    <mxGraphModel dx="4821" dy="3185" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+    <mxGraphModel dx="6552" dy="3760" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
       <root>
         <mxCell id="WIyWlLk6GJQsqaUBKTNV-0" />
         <mxCell id="WIyWlLk6GJQsqaUBKTNV-1" parent="WIyWlLk6GJQsqaUBKTNV-0" />
@@ -74,7 +74,7 @@
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-204" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-202">
           <mxGeometry x="-0.089" y="3" relative="1" as="geometry">
-            <mxPoint as="offset" />
+            <mxPoint x="-3" y="-56" as="offset" />
           </mxGeometry>
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-196" value="Enity: Fleet" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
@@ -256,6 +256,252 @@
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-290" value="Component Exp" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
           <mxGeometry x="-1340" y="-1090" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-296" value="Component Attributes" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1340" y="1030" width="140" height="90" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-297" value="strength: int&lt;br&gt;agility: int&lt;br&gt;intelligence: int&lt;br&gt;charisma: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-296">
+          <mxGeometry y="20" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-298" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-297" target="llKzF4pOKXRGiBNKoP57-172">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-316" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=70;exitDy=80;exitPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-305" target="llKzF4pOKXRGiBNKoP57-172">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="-1540" y="630" />
+              <mxPoint x="-960" y="630" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-317" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-316">
+          <mxGeometry x="-0.0919" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-305" value="Enity: Skills" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1610" y="505" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-346" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=119.99999999999999;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-308" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-308" value="Enity: Field Medicine" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2054" y="200" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-314" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-311" target="llKzF4pOKXRGiBNKoP57-308">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-312" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2240" y="190" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-311" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-312">
+          <mxGeometry y="20" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-347" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=119.99999999999999;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-318" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-318" value="Enity: Rescuing Shipwrecks" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2054" y="320" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-319" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-321" target="llKzF4pOKXRGiBNKoP57-318">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-320" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2240" y="310" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-321" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-320">
+          <mxGeometry y="20" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-348" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=119.99999999999999;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-328" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-328" value="Enity: Prisoners Management" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2054" y="442.5" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-329" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-331" target="llKzF4pOKXRGiBNKoP57-328">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-330" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2240" y="432.5" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-331" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-330">
+          <mxGeometry y="20" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-349" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=119.99999999999999;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-332" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-332" value="Enity: Persuasion" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2054" y="570" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-333" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-335" target="llKzF4pOKXRGiBNKoP57-332">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-334" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2240" y="560" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-335" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-334">
+          <mxGeometry y="20" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-353" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-351" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-351" value="Component: Skills" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1620" y="335" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-397" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-355" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-355" value="Enity: Trade" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2054" y="690" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-356" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-358" target="llKzF4pOKXRGiBNKoP57-355">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-357" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2240" y="680" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-358" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-357">
+          <mxGeometry y="20" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-398" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-359" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-359" value="Enity: Athletics" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2054" y="810" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-360" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-362" target="llKzF4pOKXRGiBNKoP57-359">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-361" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2240" y="800" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-362" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-361">
+          <mxGeometry y="20" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-399" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-363" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-363" value="Enity: Army Command" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2054" y="932.5" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-364" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-366" target="llKzF4pOKXRGiBNKoP57-363">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-365" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2240" y="922.5" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-366" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-365">
+          <mxGeometry y="20" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-400" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-367" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-367" value="Enity: Vehicle Shooting" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2054" y="1060" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-368" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-370" target="llKzF4pOKXRGiBNKoP57-367">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-369" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2240" y="1050" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-370" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-369">
+          <mxGeometry y="20" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-395" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-371" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-371" value="Enity: Ship Command" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2054" y="-290" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-372" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-374" target="llKzF4pOKXRGiBNKoP57-371">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-373" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2240" y="-300" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-374" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-373">
+          <mxGeometry y="20" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-394" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-375" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-375" value="Enity: Detection" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2054" y="-170" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-376" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-378" target="llKzF4pOKXRGiBNKoP57-375">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-377" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2240" y="-180" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-378" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-377">
+          <mxGeometry y="20" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-393" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-379" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-379" value="Enity: Tracking" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2054" y="-47.5" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-380" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-382" target="llKzF4pOKXRGiBNKoP57-379">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-381" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2240" y="-57.5" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-382" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-381">
+          <mxGeometry y="20" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-391" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-383" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-383" value="Enity: Logistics" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2054" y="80" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-384" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-386" target="llKzF4pOKXRGiBNKoP57-383">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-385" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2240" y="70" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-386" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-385">
+          <mxGeometry y="20" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-396" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-387" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-387" value="Enity: Navigation" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2054" y="-404" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-388" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-390" target="llKzF4pOKXRGiBNKoP57-387">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-389" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2240" y="-414" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-390" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-389">
+          <mxGeometry y="20" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-408" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120.00000000000001;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-404" target="llKzF4pOKXRGiBNKoP57-305">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-409" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-408">
+          <mxGeometry x="0.8664" y="2" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-404" value="Enity: Vehicle Driving" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2054" y="1179" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-405" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-407" target="llKzF4pOKXRGiBNKoP57-404">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-406" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-2240" y="1169" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-407" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-406">
+          <mxGeometry y="20" width="140" height="50" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/server/ecs-diagram.drawio
+++ b/server/ecs-diagram.drawio
@@ -1,19 +1,14 @@
-<mxfile host="Electron" modified="2023-04-24T17:34:37.055Z" agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/21.2.1 Chrome/106.0.5249.199 Electron/21.4.3 Safari/537.36" etag="VEhAwenO1JFKADHJYiMU" version="21.2.1" type="device">
+<mxfile host="Electron" modified="2023-04-24T19:31:47.854Z" agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/21.2.1 Chrome/106.0.5249.199 Electron/21.4.3 Safari/537.36" etag="kN64lMzOJyFSkB1fINPQ" version="21.2.1" type="device">
   <diagram id="C5RBs43oDa-KdzZeNtuy" name="Page-1">
-    <mxGraphModel dx="6552" dy="3760" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+    <mxGraphModel dx="4381" dy="3547" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
       <root>
         <mxCell id="WIyWlLk6GJQsqaUBKTNV-0" />
         <mxCell id="WIyWlLk6GJQsqaUBKTNV-1" parent="WIyWlLk6GJQsqaUBKTNV-0" />
-        <mxCell id="llKzF4pOKXRGiBNKoP57-170" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-172" target="llKzF4pOKXRGiBNKoP57-184">
+        <mxCell id="llKzF4pOKXRGiBNKoP57-451" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0;entryY=0;entryDx=70;entryDy=80;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-172" target="llKzF4pOKXRGiBNKoP57-184">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-171" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-172" target="llKzF4pOKXRGiBNKoP57-185">
+        <mxCell id="llKzF4pOKXRGiBNKoP57-452" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.582;entryY=0.009;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-172" target="llKzF4pOKXRGiBNKoP57-185">
           <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-279" value="Created" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-171">
-          <mxGeometry x="-0.5771" y="-1" relative="1" as="geometry">
-            <mxPoint x="-7" y="-1" as="offset" />
-          </mxGeometry>
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-172" value="Admiral Bundle" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
           <mxGeometry x="-1070" y="770" width="220" height="165" as="geometry" />
@@ -36,7 +31,7 @@
         <mxCell id="llKzF4pOKXRGiBNKoP57-178" value="Component Race" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
           <mxGeometry x="-1340" y="935" width="140" height="50" as="geometry" />
         </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-179" value="race: enum" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-178">
+        <mxCell id="llKzF4pOKXRGiBNKoP57-179" value="race: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-178">
           <mxGeometry y="20" width="140" height="30" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-180" value="Component Name" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
@@ -52,22 +47,22 @@
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-184" value="Enity: Player" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-610" y="735" width="120" height="80" as="geometry" />
+          <mxGeometry x="-312" y="724.5" width="120" height="80" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-185" value="Enity: NPC" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-610" y="890" width="120" height="80" as="geometry" />
+          <mxGeometry x="-312" y="879.5" width="120" height="80" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-186" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-187" target="llKzF4pOKXRGiBNKoP57-184">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-187" value="Component: Player" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-790" y="640" width="140" height="50" as="geometry" />
+          <mxGeometry x="-470" y="637.5" width="140" height="50" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-188" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-189" target="llKzF4pOKXRGiBNKoP57-185">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-189" value="Component: NPC" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-790" y="1020" width="140" height="50" as="geometry" />
+          <mxGeometry x="-470" y="1017.5" width="140" height="50" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-202" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-196" target="llKzF4pOKXRGiBNKoP57-172">
           <mxGeometry relative="1" as="geometry" />
@@ -103,6 +98,19 @@
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-535" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=70;exitDy=80;exitPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-203" target="llKzF4pOKXRGiBNKoP57-502">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="-960" y="160" />
+              <mxPoint x="-960" y="190" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-536" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-535">
+          <mxGeometry x="0.3192" relative="1" as="geometry">
+            <mxPoint x="52" as="offset" />
+          </mxGeometry>
+        </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-203" value="Enity: Ship" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
           <mxGeometry x="-1020" y="80" width="120" height="80" as="geometry" />
         </mxCell>
@@ -130,7 +138,7 @@
         <mxCell id="llKzF4pOKXRGiBNKoP57-218" value="Component Name" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
           <mxGeometry x="-1340" y="140" width="140" height="50" as="geometry" />
         </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-225" value="class: enum" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+        <mxCell id="llKzF4pOKXRGiBNKoP57-225" value="class: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
           <mxGeometry x="-1340" y="250" width="140" height="30" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-238" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-226" target="llKzF4pOKXRGiBNKoP57-203">
@@ -162,41 +170,41 @@
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-242" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-241">
           <mxGeometry x="0.1057" y="1" relative="1" as="geometry">
-            <mxPoint y="-1" as="offset" />
+            <mxPoint x="-1" y="148" as="offset" />
           </mxGeometry>
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-240" value="Enity: Section" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1020" y="-440" width="120" height="80" as="geometry" />
+          <mxGeometry x="-1020" y="-508.75" width="120" height="80" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-262" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-249" target="llKzF4pOKXRGiBNKoP57-240">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-249" value="Component: Section" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-304" width="140" height="50" as="geometry" />
+          <mxGeometry x="-1340" y="-372.75" width="140" height="50" as="geometry" />
         </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-251" value="type: enum" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-374" width="140" height="30" as="geometry" />
+        <mxCell id="llKzF4pOKXRGiBNKoP57-251" value="type: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1340" y="-442.75" width="140" height="30" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-263" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-252" target="llKzF4pOKXRGiBNKoP57-240">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-252" value="Component Type" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-394" width="140" height="50" as="geometry" />
+          <mxGeometry x="-1340" y="-462.75" width="140" height="50" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-258" value="Component Crew" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-494" width="140" height="60" as="geometry" />
+          <mxGeometry x="-1340" y="-562.75" width="140" height="60" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-259" value="count: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-258">
           <mxGeometry y="20" width="140" height="40" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-260" value="morale: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-564" width="140" height="30" as="geometry" />
+          <mxGeometry x="-1340" y="-632.75" width="140" height="30" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-265" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-261" target="llKzF4pOKXRGiBNKoP57-240">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-261" value="Component Morale" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-584" width="140" height="50" as="geometry" />
+          <mxGeometry x="-1340" y="-652.75" width="140" height="50" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-264" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-259" target="llKzF4pOKXRGiBNKoP57-240">
           <mxGeometry relative="1" as="geometry" />
@@ -204,58 +212,64 @@
         <mxCell id="llKzF4pOKXRGiBNKoP57-267" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-266" target="llKzF4pOKXRGiBNKoP57-240">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-268" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-267">
-          <mxGeometry x="-0.0497" y="1" relative="1" as="geometry">
+        <mxCell id="llKzF4pOKXRGiBNKoP57-539" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-267">
+          <mxGeometry x="0.6533" y="1" relative="1" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-538" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=70;exitDy=80;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-266" target="llKzF4pOKXRGiBNKoP57-504">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="-960" y="-911" />
+              <mxPoint x="-960" y="-720" />
+              <mxPoint x="-680" y="-720" />
+              <mxPoint x="-680" y="-88" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-540" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-538">
+          <mxGeometry x="0.8249" relative="1" as="geometry">
+            <mxPoint x="54" as="offset" />
+          </mxGeometry>
+        </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-266" value="Enity: Specialist" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1020" y="-890" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-272" value="Component Morale" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-730" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-273" value="morale: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-272">
-          <mxGeometry y="20" width="140" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-274" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-273" target="llKzF4pOKXRGiBNKoP57-266">
-          <mxGeometry relative="1" as="geometry" />
+          <mxGeometry x="-1020" y="-991" width="120" height="80" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-283" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-281" target="llKzF4pOKXRGiBNKoP57-266">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-281" value="type: enum" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-800" width="140" height="30" as="geometry" />
+        <mxCell id="llKzF4pOKXRGiBNKoP57-281" value="type: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1340" y="-827.5" width="140" height="30" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-282" value="Component Type" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-820" width="140" height="50" as="geometry" />
+          <mxGeometry x="-1340" y="-847.5" width="140" height="50" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-284" value="morale: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-890" width="140" height="30" as="geometry" />
+          <mxGeometry x="-1340" y="-917.5" width="140" height="30" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-286" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-285" target="llKzF4pOKXRGiBNKoP57-266">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-285" value="Component Morale" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-910" width="140" height="50" as="geometry" />
+          <mxGeometry x="-1340" y="-937.5" width="140" height="50" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-292" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-287" target="llKzF4pOKXRGiBNKoP57-266">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-287" value="level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-980" width="140" height="30" as="geometry" />
+          <mxGeometry x="-1340" y="-1007.5" width="140" height="30" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-288" value="Component Level" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-1000" width="140" height="50" as="geometry" />
+          <mxGeometry x="-1340" y="-1027.5" width="140" height="50" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-291" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-289" target="llKzF4pOKXRGiBNKoP57-266">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-289" value="level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-1070" width="140" height="30" as="geometry" />
+          <mxGeometry x="-1340" y="-1097.5" width="140" height="30" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-290" value="Component Exp" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1340" y="-1090" width="140" height="50" as="geometry" />
+          <mxGeometry x="-1340" y="-1117.5" width="140" height="50" as="geometry" />
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-296" value="Component Attributes" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
           <mxGeometry x="-1340" y="1030" width="140" height="90" as="geometry" />
@@ -280,228 +294,502 @@
           </mxGeometry>
         </mxCell>
         <mxCell id="llKzF4pOKXRGiBNKoP57-305" value="Enity: Skills" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1610" y="505" width="120" height="80" as="geometry" />
+          <mxGeometry x="-1600" y="480" width="120" height="80" as="geometry" />
         </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-346" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=119.99999999999999;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-308" target="llKzF4pOKXRGiBNKoP57-305">
+        <mxCell id="llKzF4pOKXRGiBNKoP57-500" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=70;exitDy=80;exitPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-318" target="llKzF4pOKXRGiBNKoP57-305">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-308" value="Enity: Field Medicine" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2054" y="200" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-314" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-311" target="llKzF4pOKXRGiBNKoP57-308">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-312" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2240" y="190" width="140" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-311" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-312">
-          <mxGeometry y="20" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-347" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=119.99999999999999;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-318" target="llKzF4pOKXRGiBNKoP57-305">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-318" value="Enity: Rescuing Shipwrecks" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2054" y="320" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-319" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-321" target="llKzF4pOKXRGiBNKoP57-318">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-320" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2240" y="310" width="140" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-321" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-320">
-          <mxGeometry y="20" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-348" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=119.99999999999999;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-328" target="llKzF4pOKXRGiBNKoP57-305">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-328" value="Enity: Prisoners Management" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2054" y="442.5" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-329" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-331" target="llKzF4pOKXRGiBNKoP57-328">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-330" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2240" y="432.5" width="140" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-331" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-330">
-          <mxGeometry y="20" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-349" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=119.99999999999999;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-332" target="llKzF4pOKXRGiBNKoP57-305">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-332" value="Enity: Persuasion" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2054" y="570" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-333" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-335" target="llKzF4pOKXRGiBNKoP57-332">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-334" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2240" y="560" width="140" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-335" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-334">
-          <mxGeometry y="20" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-353" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-351" target="llKzF4pOKXRGiBNKoP57-305">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-351" value="Component: Skills" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-1620" y="335" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-397" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-355" target="llKzF4pOKXRGiBNKoP57-305">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-355" value="Enity: Trade" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2054" y="690" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-356" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-358" target="llKzF4pOKXRGiBNKoP57-355">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-357" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2240" y="680" width="140" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-358" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-357">
-          <mxGeometry y="20" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-398" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-359" target="llKzF4pOKXRGiBNKoP57-305">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-359" value="Enity: Athletics" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2054" y="810" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-360" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-362" target="llKzF4pOKXRGiBNKoP57-359">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-361" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2240" y="800" width="140" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-362" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-361">
-          <mxGeometry y="20" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-399" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-363" target="llKzF4pOKXRGiBNKoP57-305">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-363" value="Enity: Army Command" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2054" y="932.5" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-364" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-366" target="llKzF4pOKXRGiBNKoP57-363">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-365" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2240" y="922.5" width="140" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-366" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-365">
-          <mxGeometry y="20" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-400" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-367" target="llKzF4pOKXRGiBNKoP57-305">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-367" value="Enity: Vehicle Shooting" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2054" y="1060" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-368" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-370" target="llKzF4pOKXRGiBNKoP57-367">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-369" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2240" y="1050" width="140" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-370" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-369">
-          <mxGeometry y="20" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-395" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-371" target="llKzF4pOKXRGiBNKoP57-305">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-371" value="Enity: Ship Command" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2054" y="-290" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-372" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-374" target="llKzF4pOKXRGiBNKoP57-371">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-373" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2240" y="-300" width="140" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-374" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-373">
-          <mxGeometry y="20" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-394" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-375" target="llKzF4pOKXRGiBNKoP57-305">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-375" value="Enity: Detection" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2054" y="-170" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-376" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-378" target="llKzF4pOKXRGiBNKoP57-375">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-377" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2240" y="-180" width="140" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-378" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-377">
-          <mxGeometry y="20" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-393" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-379" target="llKzF4pOKXRGiBNKoP57-305">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-379" value="Enity: Tracking" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2054" y="-47.5" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-380" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-382" target="llKzF4pOKXRGiBNKoP57-379">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-381" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2240" y="-57.5" width="140" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-382" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-381">
-          <mxGeometry y="20" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-391" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-383" target="llKzF4pOKXRGiBNKoP57-305">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-383" value="Enity: Logistics" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2054" y="80" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-384" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-386" target="llKzF4pOKXRGiBNKoP57-383">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-385" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2240" y="70" width="140" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-386" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-385">
-          <mxGeometry y="20" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-396" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-387" target="llKzF4pOKXRGiBNKoP57-305">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-387" value="Enity: Navigation" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2054" y="-404" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-388" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-390" target="llKzF4pOKXRGiBNKoP57-387">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-389" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2240" y="-414" width="140" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-390" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-389">
-          <mxGeometry y="20" width="140" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-408" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120.00000000000001;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-404" target="llKzF4pOKXRGiBNKoP57-305">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-409" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-408">
-          <mxGeometry x="0.8664" y="2" relative="1" as="geometry">
+        <mxCell id="llKzF4pOKXRGiBNKoP57-661" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-500">
+          <mxGeometry x="-0.1145" relative="1" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-404" value="Enity: Vehicle Driving" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2054" y="1179" width="120" height="80" as="geometry" />
+        <mxCell id="llKzF4pOKXRGiBNKoP57-318" value="Enity: Skill" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1610" y="265" width="120" height="80" as="geometry" />
         </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-405" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.006;entryY=0.442;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-407" target="llKzF4pOKXRGiBNKoP57-404">
+        <mxCell id="llKzF4pOKXRGiBNKoP57-412" value="Enity: Star System" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="320" y="485" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-419" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" target="llKzF4pOKXRGiBNKoP57-172">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-1200" y="1194.030303030303" as="sourcePoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-429" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-420" target="llKzF4pOKXRGiBNKoP57-412">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="260" y="179" />
+              <mxPoint x="380" y="179" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-420" value="Enity: Planet" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="190" y="20" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-428" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-421" target="llKzF4pOKXRGiBNKoP57-412">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="50" y="179" />
+              <mxPoint x="380" y="179" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-421" value="Enity: Big Station" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-10" y="20" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-431" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-422" target="llKzF4pOKXRGiBNKoP57-412">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="740" y="179" />
+              <mxPoint x="380" y="179" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-422" value="Enity: Small Station" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="670" y="20" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-627" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=70;exitDy=80;exitPerimeter=0;entryX=0.5;entryY=-0.007;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-423" target="llKzF4pOKXRGiBNKoP57-412">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="440" y="422.56410256410254" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="540" y="179" />
+              <mxPoint x="380" y="179" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-628" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-627">
+          <mxGeometry x="0.8386" y="-1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-423" value="Enity: Factory Station" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="470" y="20" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-426" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-424" target="llKzF4pOKXRGiBNKoP57-412">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-406" value="Component Skill" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
-          <mxGeometry x="-2240" y="1169" width="140" height="70" as="geometry" />
+        <mxCell id="llKzF4pOKXRGiBNKoP57-424" value="Component: Start System" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="79" y="365" width="140" height="50" as="geometry" />
         </mxCell>
-        <mxCell id="llKzF4pOKXRGiBNKoP57-407" value="name: string&lt;br&gt;level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-406">
-          <mxGeometry y="20" width="140" height="50" as="geometry" />
+        <mxCell id="llKzF4pOKXRGiBNKoP57-432" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=50;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-427" target="llKzF4pOKXRGiBNKoP57-420">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="390" y="-70" />
+              <mxPoint x="240" y="-70" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-433" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0;entryY=0;entryDx=50;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-427" target="llKzF4pOKXRGiBNKoP57-423">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="390" y="-70" />
+              <mxPoint x="520" y="-70" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-434" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0;entryY=0;entryDx=50;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-427" target="llKzF4pOKXRGiBNKoP57-422">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="390" y="-70" />
+              <mxPoint x="720" y="-70" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-436" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-427" target="llKzF4pOKXRGiBNKoP57-421">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="390" y="-70" />
+              <mxPoint x="50" y="-70" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-427" value="Location Bundle" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="280" y="-419" width="220" height="165" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-541" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=120.00000000000001;entryDy=50;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-437" target="llKzF4pOKXRGiBNKoP57-185">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="380" y="-840" />
+              <mxPoint x="1030" y="-840" />
+              <mxPoint x="1030" y="930" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-543" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-541">
+          <mxGeometry x="0.9614" relative="1" as="geometry">
+            <mxPoint x="8" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-592" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.501;exitY=0.975;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-437">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="390" y="-420" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="380" y="-840" />
+              <mxPoint x="1030" y="-840" />
+              <mxPoint x="1030" y="-520" />
+              <mxPoint x="390" y="-520" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-437" value="Enity: Quest" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="320" y="-1087.5" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-438" value="Component Fraction" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-20" y="-345.25" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-439" value="fraction: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-438">
+          <mxGeometry y="20" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-464" value="Component Fraction" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1340" y="1169" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-465" value="fraction: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-464">
+          <mxGeometry y="20" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-476" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-466" target="llKzF4pOKXRGiBNKoP57-437">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-466" value="Component Reward" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-20" y="-1013.5" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-467" value="money: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-466">
+          <mxGeometry y="20" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-469" value="Component Name" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-20" y="-1187.5" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-470" value="name: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-469">
+          <mxGeometry y="20" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-471" value="Component Fraction Rewand" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-70" y="-926.5" width="190" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-472" value="reputation: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-471">
+          <mxGeometry y="20" width="190" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-477" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-470" target="llKzF4pOKXRGiBNKoP57-437">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-478" value="Component Description" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-37" y="-1107.5" width="157" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-479" value="description: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-478">
+          <mxGeometry y="20" width="157" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-481" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-479" target="llKzF4pOKXRGiBNKoP57-437">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-494" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-486" target="llKzF4pOKXRGiBNKoP57-318">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-486" value="Component: Skill" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1883" y="125" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-488" value="level: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1883" y="235" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-495" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-489" target="llKzF4pOKXRGiBNKoP57-318">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-489" value="Component Level" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1883" y="215" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-490" value="Component Name" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1883" y="303" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-491" value="name: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-490">
+          <mxGeometry y="20" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-492" value="Component Description" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1900" y="383" width="157" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-493" value="description: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-492">
+          <mxGeometry y="20" width="157" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-496" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-491" target="llKzF4pOKXRGiBNKoP57-318">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-497" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-493" target="llKzF4pOKXRGiBNKoP57-318">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-499" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-498" target="llKzF4pOKXRGiBNKoP57-437">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-498" value="Component: Quest" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-20" y="-1273.5" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-513" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;entryPerimeter=0;exitX=0;exitY=0;exitDx=70;exitDy=80;exitPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-501" target="llKzF4pOKXRGiBNKoP57-427">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="390" y="-568" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-514" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-513">
+          <mxGeometry x="0.8902" y="-2" relative="1" as="geometry">
+            <mxPoint x="2" y="-38" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-501" value="Enity: Shop" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="330" y="-648" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-578" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.301;entryY=0.001;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-502" target="llKzF4pOKXRGiBNKoP57-421">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="-360" y="190" />
+              <mxPoint x="-360" y="-20" />
+              <mxPoint x="26" y="-20" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-579" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-578">
+          <mxGeometry x="0.9287" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-502" value="Enity: Shipyard" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-534" y="150" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-577" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.236;entryY=0.002;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-504" target="llKzF4pOKXRGiBNKoP57-420">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="-474" y="-20" />
+              <mxPoint x="218" y="-20" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-580" value="Child" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-577">
+          <mxGeometry x="0.9252" y="-1" relative="1" as="geometry">
+            <mxPoint x="2" y="5" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-504" value="Enity: Universitiy" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-534" y="-117.5" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-510" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-508" target="llKzF4pOKXRGiBNKoP57-427">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-508" value="Component Owner" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-20" y="-255.25" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-509" value="id: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-508">
+          <mxGeometry y="20" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-511" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-439" target="llKzF4pOKXRGiBNKoP57-427">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-532" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-472" target="llKzF4pOKXRGiBNKoP57-437">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-660" value="optional" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-532">
+          <mxGeometry x="-0.7657" y="2" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-551" value="price: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1340" y="-1187.5" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-555" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-552" target="llKzF4pOKXRGiBNKoP57-266">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-552" value="Component Price" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1340" y="-1207.5" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-556" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-553" target="llKzF4pOKXRGiBNKoP57-266">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-553" value="Salary: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1340" y="-1277.5" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-554" value="Component Salary" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1340" y="-1297.5" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-564" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-561" target="llKzF4pOKXRGiBNKoP57-504">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-561" value="Component: University" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-640" y="-254" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-563" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=70;entryDy=80;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-562" target="llKzF4pOKXRGiBNKoP57-502">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-562" value="Component: Shipyard" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-630" y="320" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-590" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-565" target="llKzF4pOKXRGiBNKoP57-421">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="10" y="-10" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-120" y="-70" />
+              <mxPoint x="10" y="-70" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-565" value="Component: Big Station" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-260" y="-100" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-591" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-566" target="llKzF4pOKXRGiBNKoP57-420">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="250" y="-142" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-566" value="Component: Planet" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-260" y="-167.5" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-586" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-567" target="llKzF4pOKXRGiBNKoP57-423">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-567" value="Component: Factory" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="810" y="-167.5" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-587" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-568" target="llKzF4pOKXRGiBNKoP57-422">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="810" y="-70" />
+              <mxPoint x="730" y="-70" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-568" value="Component: University" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="810" y="-90" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-593" value="Component Money" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-20" y="-690" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-594" value="money: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-593">
+          <mxGeometry y="20" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-596" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-595" target="llKzF4pOKXRGiBNKoP57-501">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-595" value="Component: Shop" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-20" y="-780" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-597" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-594" target="llKzF4pOKXRGiBNKoP57-501">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-599" value="Component Money" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-640" y="-344" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-600" value="money: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-599">
+          <mxGeometry y="20" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-601" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-600" target="llKzF4pOKXRGiBNKoP57-504">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-602" value="Component Money" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-630" y="410" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-603" value="money: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-602">
+          <mxGeometry y="20" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-604" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=70;entryDy=80;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-603" target="llKzF4pOKXRGiBNKoP57-502">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-605" value="Component Name" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-20" y="-427.75" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-606" value="name: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-605">
+          <mxGeometry y="20" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-607" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-606" target="llKzF4pOKXRGiBNKoP57-427">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-608" value="Component Name" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="79" y="440" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-609" value="name: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-608">
+          <mxGeometry y="20" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-610" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-609" target="llKzF4pOKXRGiBNKoP57-412">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-617" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-616" target="llKzF4pOKXRGiBNKoP57-427">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-616" value="Component: Location" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-20" y="-512.75" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-620" value="Component Fraction" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="79" y="515" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-621" value="fraction: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-620">
+          <mxGeometry y="20" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-622" value="Component Owner" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="79" y="605" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-623" value="id: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="llKzF4pOKXRGiBNKoP57-622">
+          <mxGeometry y="20" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-624" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-621" target="llKzF4pOKXRGiBNKoP57-412">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-625" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-623" target="llKzF4pOKXRGiBNKoP57-412">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-632" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0;exitDx=120;exitDy=50;exitPerimeter=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-629" target="llKzF4pOKXRGiBNKoP57-501">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-629" value="Enity: Item" style="shape=cube;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;darkOpacity=0.05;darkOpacity2=0.1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-237" y="-668" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-635" value="price: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1340" y="-197.5" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-637" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-636" target="llKzF4pOKXRGiBNKoP57-203">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-636" value="Component Price" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1340" y="-217.5" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-646" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-638" target="llKzF4pOKXRGiBNKoP57-629">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-638" value="name: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-460" y="-565" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-639" value="Component Name" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-460" y="-585" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-644" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-640" target="llKzF4pOKXRGiBNKoP57-629">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-640" value="price: int" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-460" y="-653" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-641" value="Component Price" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=20;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-460" y="-673" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-645" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0;entryDx=0;entryDy=30;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-642" target="llKzF4pOKXRGiBNKoP57-629">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-642" value="Component: Item" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-460" y="-765" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-657" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-653" target="llKzF4pOKXRGiBNKoP57-172">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-658" value="optional" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-657">
+          <mxGeometry x="-0.9111" y="1" relative="1" as="geometry">
+            <mxPoint x="5" y="1" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-653" value="Component: Dictator" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1340" y="1260" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-655" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="WIyWlLk6GJQsqaUBKTNV-1" source="llKzF4pOKXRGiBNKoP57-654" target="llKzF4pOKXRGiBNKoP57-172">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-659" value="optional" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="llKzF4pOKXRGiBNKoP57-655">
+          <mxGeometry x="-0.916" y="-1" relative="1" as="geometry">
+            <mxPoint x="5" y="-2" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="llKzF4pOKXRGiBNKoP57-654" value="Component: Marshal" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="WIyWlLk6GJQsqaUBKTNV-1">
+          <mxGeometry x="-1340" y="1350" width="140" height="50" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>


### PR DESCRIPTION
This pull request adds new entities to the ECS diagram in order to document planned features in the game.

The following entities have been added:
- Skills: To document the player skill tree
- Locations and quests: To document the planned map and quest implementation
- Shops, shipyards, and universities: To document the planned economy implementation